### PR TITLE
Use explicit text formatting for portability

### DIFF
--- a/src/ch02/tsunami.f90
+++ b/src/ch02/tsunami.f90
@@ -20,6 +20,8 @@ program tsunami
   integer, parameter :: icenter = 25
   real, parameter :: decay = 0.02
 
+  character(*), parameter :: fmt = '(i0,1x,*(es15.8e2))'
+
   ! check input parameter values
   if (grid_size <= 0) stop 'grid_size must be > 0'
   if (dt <= 0) stop 'time step dt must be > 0'
@@ -32,7 +34,7 @@ program tsunami
   end do
 
   ! write initial state to screen
-  print *, 0, h
+  print fmt, 0, h
 
   time_loop: do n = 1, num_time_steps
 
@@ -50,7 +52,7 @@ program tsunami
     end do
 
     ! write current state to screen
-    print *, n, h
+    print fmt, 0, h
 
   end do time_loop
 

--- a/src/ch03/tsunami.f90
+++ b/src/ch03/tsunami.f90
@@ -23,6 +23,8 @@ program tsunami
   integer, parameter :: icenter = 25
   real, parameter :: decay = 0.02
 
+  character(*), parameter :: fmt = '(i0,1x,*(es15.8e2))'
+
   ! check input parameter values
   if (grid_size <= 0) stop 'grid_size must be > 0'
   if (dt <= 0) stop 'time step dt must be > 0'
@@ -33,7 +35,7 @@ program tsunami
   call set_gaussian(h, icenter, decay)
 
   ! write initial state to screen
-  print *, 0, h
+  print fmt, 0, h
 
   time_loop: do n = 1, num_time_steps
 
@@ -41,7 +43,7 @@ program tsunami
     h = h - c * diff(h) / dx * dt
 
     ! write current state to screen
-    print *, n, h
+    print fmt, n, h
 
   end do time_loop
 

--- a/src/ch04/tsunami.f90
+++ b/src/ch04/tsunami.f90
@@ -30,6 +30,8 @@ program tsunami
   integer(int32), parameter :: icenter = 25
   real(real32), parameter :: decay = 0.02
 
+  character(*), parameter :: fmt = '(i0,1x,*(es15.8e2))'
+
   ! check input parameter values
   if (grid_size <= 0) stop 'grid_size must be > 0'
   if (dt <= 0) stop 'time step dt must be > 0'
@@ -42,7 +44,7 @@ program tsunami
   u = 0
 
   ! write initial state to screen
-  print *, 0, h
+  print fmt, 0, h
 
   time_loop: do n = 1, num_time_steps
 
@@ -53,7 +55,7 @@ program tsunami
     h = h - diff(u * (hmean + h)) / dx * dt
 
     ! write current state to screen
-    print *, n, h
+    print fmt, n, h
 
   end do time_loop
 

--- a/src/ch07/tsunami.f90
+++ b/src/ch07/tsunami.f90
@@ -38,6 +38,8 @@ program tsunami
   integer(int32) :: ims, ime ! local start and end memory indices
   integer(int32) :: tile_size
 
+  character(*), parameter :: fmt = '(i0,1x,*(es15.8e2))'
+
   if (mod(grid_size, num_images()) > 0) then
     error stop 'Error: grid_size must be divisible by number of images'
   end if
@@ -74,7 +76,7 @@ program tsunami
   ! gather to image 1 and write current state to screen
   gather(is:ie)[1] = h(ils:ile)
   sync all
-  if (this_image() == 1) print *, 0, gather
+  if (this_image() == 1) print fmt, 0, gather
 
   time_loop: do n = 1, num_time_steps
 
@@ -99,7 +101,7 @@ program tsunami
     ! gather to image 1 and write current state to screen
     gather(is:ie)[1] = h(ils:ile)
     sync all
-    if (this_image() == 1) print *, n, gather
+    if (this_image() == 1) print fmt, n, gather
 
   end do time_loop
 


### PR DESCRIPTION
Diverges a bit from the book, but makes the text output in Chapter 2, 3, 4, and 7 portable between compilers.