### PR TITLE
Fix edit descriptor in output format

### DIFF
--- a/src/ch02/tsunami.f90
+++ b/src/ch02/tsunami.f90
@@ -20,7 +20,7 @@ program tsunami
   integer, parameter :: icenter = 25
   real, parameter :: decay = 0.02
 
-  character(*), parameter :: fmt = '(i0,1x,*(es15.8e2))'
+  character(*), parameter :: fmt = '(i0,*(1x,es15.8e2))'
 
   ! check input parameter values
   if (grid_size <= 0) stop 'grid_size must be > 0'

--- a/src/ch03/tsunami.f90
+++ b/src/ch03/tsunami.f90
@@ -23,7 +23,7 @@ program tsunami
   integer, parameter :: icenter = 25
   real, parameter :: decay = 0.02
 
-  character(*), parameter :: fmt = '(i0,1x,*(es15.8e2))'
+  character(*), parameter :: fmt = '(i0,*(1x,es15.8e2))'
 
   ! check input parameter values
   if (grid_size <= 0) stop 'grid_size must be > 0'

--- a/src/ch04/tsunami.f90
+++ b/src/ch04/tsunami.f90
@@ -30,7 +30,7 @@ program tsunami
   integer(int32), parameter :: icenter = 25
   real(real32), parameter :: decay = 0.02
 
-  character(*), parameter :: fmt = '(i0,1x,*(es15.8e2))'
+  character(*), parameter :: fmt = '(i0,*(1x,es15.8e2))'
 
   ! check input parameter values
   if (grid_size <= 0) stop 'grid_size must be > 0'

--- a/src/ch07/tsunami.f90
+++ b/src/ch07/tsunami.f90
@@ -38,7 +38,7 @@ program tsunami
   integer(int32) :: ims, ime ! local start and end memory indices
   integer(int32) :: tile_size
 
-  character(*), parameter :: fmt = '(i0,1x,*(es15.8e2))'
+  character(*), parameter :: fmt = '(i0,*(1x,es15.8e2))'
 
   if (mod(grid_size, num_images()) > 0) then
     error stop 'Error: grid_size must be divisible by number of images'


### PR DESCRIPTION
This fixes the edit descriptor that had `1x` in the wrong place.

Thanks to Patrick Le Roux for reporting.